### PR TITLE
chore: replace stale bge-large-en-v1.5 references with snowflake-arctic-embed-m

### DIFF
--- a/crates/tldr-cli/src/commands/daemon/spec.md
+++ b/crates/tldr-cli/src/commands/daemon/spec.md
@@ -83,7 +83,7 @@ impl Default for DaemonConfig {
         Self {
             semantic_enabled: true,
             auto_reindex_threshold: DEFAULT_REINDEX_THRESHOLD,
-            semantic_model: "bge-large-en-v1.5".to_string(),
+            semantic_model: "snowflake-arctic-embed-m".to_string(),
             idle_timeout_secs: IDLE_TIMEOUT.as_secs(),
         }
     }

--- a/crates/tldr-cli/src/commands/daemon/types.rs
+++ b/crates/tldr-cli/src/commands/daemon/types.rs
@@ -51,7 +51,7 @@ impl Default for DaemonConfig {
         Self {
             semantic_enabled: true,
             auto_reindex_threshold: DEFAULT_REINDEX_THRESHOLD,
-            semantic_model: "bge-large-en-v1.5".to_string(),
+            semantic_model: "snowflake-arctic-embed-m".to_string(),
             idle_timeout_secs: IDLE_TIMEOUT_SECS,
         }
     }
@@ -537,7 +537,7 @@ mod tests {
 
         assert!(config.semantic_enabled);
         assert_eq!(config.auto_reindex_threshold, DEFAULT_REINDEX_THRESHOLD);
-        assert_eq!(config.semantic_model, "bge-large-en-v1.5");
+        assert_eq!(config.semantic_model, "snowflake-arctic-embed-m");
         assert_eq!(config.idle_timeout_secs, IDLE_TIMEOUT_SECS);
     }
 

--- a/crates/tldr-cli/tests/daemon_test.rs
+++ b/crates/tldr-cli/tests/daemon_test.rs
@@ -79,7 +79,7 @@ mod daemon_types {
             Self {
                 semantic_enabled: true,
                 auto_reindex_threshold: DEFAULT_REINDEX_THRESHOLD,
-                semantic_model: "bge-large-en-v1.5".to_string(),
+                semantic_model: "snowflake-arctic-embed-m".to_string(),
                 idle_timeout_secs: IDLE_TIMEOUT_SECS,
             }
         }
@@ -256,7 +256,7 @@ mod unit_types {
 
         assert!(config.semantic_enabled);
         assert_eq!(config.auto_reindex_threshold, DEFAULT_REINDEX_THRESHOLD);
-        assert_eq!(config.semantic_model, "bge-large-en-v1.5");
+        assert_eq!(config.semantic_model, "snowflake-arctic-embed-m");
         assert_eq!(config.idle_timeout_secs, IDLE_TIMEOUT_SECS);
     }
 

--- a/crates/tldr-core/src/search/embedding_client.rs
+++ b/crates/tldr-core/src/search/embedding_client.rs
@@ -20,8 +20,8 @@ pub const DEFAULT_EMBEDDING_URL: &str = "http://localhost:8765";
 /// Default timeout for embedding requests
 pub const DEFAULT_TIMEOUT: Duration = Duration::from_secs(10);
 
-/// Embedding vector dimension (for BGE-large-en-v1.5)
-pub const EMBEDDING_DIM: usize = 1024;
+/// Embedding vector dimension (stale placeholder — actual embeddings use Snowflake Arctic via fastembed-rs)
+pub const EMBEDDING_DIM: usize = 768;
 
 /// Request to the embedding service
 #[derive(Debug, Clone, Serialize)]


### PR DESCRIPTION
## Summary

The project switched from a planned BGE-via-Python-sidecar approach to Snowflake Arctic embeddings via `fastembed-rs`, but several stale references to `bge-large-en-v1.5` were left behind across 4 files.

- Update `DaemonConfig::default()` `semantic_model` to `"snowflake-arctic-embed-m"`
- Fix `EMBEDDING_DIM` constant and comment in the `embedding_client` stub to reflect actual model (768 dims, not 1024)
- Update all tests and spec doc accordingly

## Files changed

| File | Change |
|------|--------|
| `crates/tldr-core/src/search/embedding_client.rs` | Fix stale `BGE-large-en-v1.5` comment and `EMBEDDING_DIM` (1024 → 768) |
| `crates/tldr-cli/src/commands/daemon/types.rs` | `DaemonConfig` default + test assertion |
| `crates/tldr-cli/tests/daemon_test.rs` | Default struct + assertion |
| `crates/tldr-cli/src/commands/daemon/spec.md` | Spec doc |

## Test plan

- [ ] `cargo test -p tldr-cli` — daemon config default and serialization tests pass
- [ ] `cargo test -p tldr-core` — no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated default semantic embedding model.
  * Adjusted embedding dimension configuration.
  * Updated tests to reflect those configuration changes

* **New Features**
  * Added Beads integration: git hook scripts, ignore rules, and local metadata/issue seeds.

* **Documentation**
  * Added agent instructions and project guidance documents for AI-assisted workflows.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/parcadei/tldr-code/pull/49?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->