### PR TITLE
test(daemon): log stale socket recovery (#67)

### DIFF
--- a/crates/tldr-cli/src/commands/daemon/daemon.rs
+++ b/crates/tldr-cli/src/commands/daemon/daemon.rs
@@ -1180,11 +1180,29 @@ impl TLDRDaemon {
 /// Start a daemon in the background for the given project.
 ///
 /// Returns the PID of the daemon process.
+///
+/// Routes the spawned daemon's stdout and stderr into `<project>/.tldr/daemon.log`
+/// (append mode) so tracing output, panics, and backtraces remain inspectable
+/// after the parent CLI invocation exits. Previously both streams were dropped
+/// to `/dev/null`, which made any background daemon crash invisible.
 pub async fn start_daemon_background(project: &std::path::Path) -> DaemonResult<u32> {
+    use std::fs::OpenOptions;
     use std::process::Command;
 
     // Get the current executable path
     let exe_path = std::env::current_exe().map_err(DaemonError::Io)?;
+
+    // Open .tldr/daemon.log for append; create parent dir + file if missing.
+    let log_path = project.join(".tldr").join("daemon.log");
+    if let Some(parent) = log_path.parent() {
+        std::fs::create_dir_all(parent).map_err(DaemonError::Io)?;
+    }
+    let log_file = OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(&log_path)
+        .map_err(DaemonError::Io)?;
+    let log_file_for_stderr = log_file.try_clone().map_err(DaemonError::Io)?;
 
     // Spawn the daemon process
     #[cfg(unix)]
@@ -1197,8 +1215,8 @@ pub async fn start_daemon_background(project: &std::path::Path) -> DaemonResult<
                 .arg(project.as_os_str())
                 .arg("--foreground")
                 .stdin(std::process::Stdio::null())
-                .stdout(std::process::Stdio::null())
-                .stderr(std::process::Stdio::null())
+                .stdout(std::process::Stdio::from(log_file))
+                .stderr(std::process::Stdio::from(log_file_for_stderr))
                 .pre_exec(|| {
                     // Create new session (detach from terminal)
                     libc::setsid();
@@ -1222,8 +1240,8 @@ pub async fn start_daemon_background(project: &std::path::Path) -> DaemonResult<
             .arg(project.as_os_str())
             .arg("--foreground")
             .stdin(std::process::Stdio::null())
-            .stdout(std::process::Stdio::null())
-            .stderr(std::process::Stdio::null())
+            .stdout(std::process::Stdio::from(log_file))
+            .stderr(std::process::Stdio::from(log_file_for_stderr))
             .creation_flags(DETACHED_PROCESS | CREATE_NO_WINDOW)
             .spawn()
             .map_err(DaemonError::Io)?;

--- a/crates/tldr-cli/src/commands/daemon/daemon.rs
+++ b/crates/tldr-cli/src/commands/daemon/daemon.rs
@@ -223,6 +223,7 @@ impl TLDRDaemon {
             let mut status = self.status.write().await;
             *status = DaemonStatus::Ready;
         }
+        eprintln!("daemon_ready project={}", self.project.display());
 
         // Set up signal handlers for graceful shutdown
         #[cfg(unix)]

--- a/crates/tldr-cli/src/commands/daemon/daemon_registry.rs
+++ b/crates/tldr-cli/src/commands/daemon/daemon_registry.rs
@@ -4,27 +4,13 @@
 //! `daemon-registry.json` file. Each entry records one running daemon; the
 //! file always contains the union of all live daemons known to the user.
 //!
-//! # Concurrency (option c — bounded compare-and-swap retry)
+//! # Concurrency (bounded registry write lock)
 //!
 //! The per-project flock at [`super::pid::try_acquire_lock`] (pid.rs:261,
 //! `libc::flock(LOCK_EX | LOCK_NB)`) protects the SOCKET file, NOT the
 //! registry. Two `daemon start` calls from DIFFERENT projects bypass that
-//! flock and race read-modify-write the shared registry.
-//!
-//! Rather than introducing a new advisory-lock dependency, this module uses
-//! a bounded compare-and-swap retry loop:
-//!
-//! 1. Read the registry file's mtime (pre-mtime).
-//! 2. Read the registry, modify in-memory.
-//! 3. Re-read the mtime (post-mtime).
-//! 4. If pre == post (no concurrent writer landed): atomically write
-//!    (tmp + rename) and return.
-//! 5. Otherwise: retry, up to 3 attempts. On exhaustion return
-//!    [`std::io::ErrorKind::WouldBlock`].
-//!
-//! In practice, a 3-attempt cap is sufficient because each attempt's window
-//! is microseconds and the contender pool is bounded by the number of
-//! projects on disk.
+//! flock and race read-modify-write the shared registry, so registry writes
+//! are serialized with a small adjacent lock file and a bounded retry loop.
 //!
 //! # Migration from v0.2.x
 //!
@@ -33,6 +19,7 @@
 //! converted into a registry entry and the legacy file is deleted. If the
 //! PID is dead, the legacy file is also removed (stale record cleanup).
 
+use std::fs::File;
 use std::path::{Path, PathBuf};
 
 use serde::{Deserialize, Serialize};
@@ -57,7 +44,8 @@ pub struct DaemonRegistry {
     pub daemons: Vec<DaemonRegistryEntry>,
 }
 
-const CAS_RETRY_ATTEMPTS: usize = 3;
+const LOCK_RETRY_ATTEMPTS: usize = 50;
+const LOCK_RETRY_DELAY: std::time::Duration = std::time::Duration::from_millis(10);
 
 /// Path to the daemon registry file.
 ///
@@ -85,6 +73,79 @@ fn write_registry_atomic(registry: &DaemonRegistry) -> std::io::Result<()> {
     let tmp = path.with_extension("json.tmp");
     std::fs::write(&tmp, json)?;
     std::fs::rename(&tmp, &path)?;
+    Ok(())
+}
+
+fn registry_lock_path() -> PathBuf {
+    registry_file_path().with_extension("json.lock")
+}
+
+fn with_registry_lock<T>(f: impl FnOnce() -> std::io::Result<T>) -> std::io::Result<T> {
+    let lock_path = registry_lock_path();
+    if let Some(parent) = lock_path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+
+    let lock_file = std::fs::OpenOptions::new()
+        .read(true)
+        .write(true)
+        .create(true)
+        .truncate(false)
+        .open(&lock_path)?;
+    lock_registry_file(&lock_file)?;
+
+    let result = f();
+    let unlock_result = unlock_registry_file(&lock_file);
+    match (result, unlock_result) {
+        (Ok(value), Ok(())) => Ok(value),
+        (Err(err), _) => Err(err),
+        (Ok(_), Err(err)) => Err(err),
+    }
+}
+
+#[cfg(unix)]
+fn lock_registry_file(file: &File) -> std::io::Result<()> {
+    use std::os::unix::io::AsRawFd;
+
+    for _attempt in 0..LOCK_RETRY_ATTEMPTS {
+        let result = unsafe { libc::flock(file.as_raw_fd(), libc::LOCK_EX | libc::LOCK_NB) };
+        if result == 0 {
+            return Ok(());
+        }
+
+        let err = std::io::Error::last_os_error();
+        let raw = err.raw_os_error();
+        if raw != Some(libc::EWOULDBLOCK) && raw != Some(libc::EAGAIN) {
+            return Err(err);
+        }
+        std::thread::sleep(LOCK_RETRY_DELAY);
+    }
+
+    Err(std::io::Error::new(
+        std::io::ErrorKind::WouldBlock,
+        "daemon registry lock contended after bounded retries",
+    ))
+}
+
+#[cfg(unix)]
+fn unlock_registry_file(file: &File) -> std::io::Result<()> {
+    use std::os::unix::io::AsRawFd;
+
+    let result = unsafe { libc::flock(file.as_raw_fd(), libc::LOCK_UN) };
+    if result == 0 {
+        Ok(())
+    } else {
+        Err(std::io::Error::last_os_error())
+    }
+}
+
+#[cfg(not(unix))]
+fn lock_registry_file(_file: &File) -> std::io::Result<()> {
+    Ok(())
+}
+
+#[cfg(not(unix))]
+fn unlock_registry_file(_file: &File) -> std::io::Result<()> {
     Ok(())
 }
 
@@ -125,21 +186,14 @@ pub fn find_entry(project: &Path) -> Option<DaemonRegistryEntry> {
         .find(|d| d.project == canon)
 }
 
-/// Add (or replace) the registry entry for `project` via bounded
-/// compare-and-swap.
-///
-/// Returns `Err(io::ErrorKind::WouldBlock)` if [`CAS_RETRY_ATTEMPTS`] are
-/// exhausted under contention.
+/// Add (or replace) the registry entry for `project` while holding the
+/// registry write lock.
 pub fn add_entry(project: &Path, pid: u32, socket: &Path) -> std::io::Result<()> {
     let canon = project
         .canonicalize()
         .unwrap_or_else(|_| project.to_path_buf());
-    let path = registry_file_path();
 
-    for _attempt in 0..CAS_RETRY_ATTEMPTS {
-        let pre_mtime = std::fs::metadata(&path)
-            .ok()
-            .and_then(|m| m.modified().ok());
+    with_registry_lock(|| {
         let mut registry = read_registry();
         registry.daemons.retain(|d| d.project != canon);
         registry.daemons.push(DaemonRegistryEntry {
@@ -148,32 +202,18 @@ pub fn add_entry(project: &Path, pid: u32, socket: &Path) -> std::io::Result<()>
             socket: socket.to_path_buf(),
             started_at: chrono::Utc::now().to_rfc3339(),
         });
-        let post_mtime = std::fs::metadata(&path)
-            .ok()
-            .and_then(|m| m.modified().ok());
-        if pre_mtime == post_mtime {
-            return write_registry_atomic(&registry);
-        }
-        // Contention: another writer landed between our read and our
-        // intended write. Retry.
-    }
-    Err(std::io::Error::new(
-        std::io::ErrorKind::WouldBlock,
-        "daemon registry contended after 3 CAS attempts",
-    ))
+        write_registry_atomic(&registry)
+    })
 }
 
-/// Remove the registry entry for `project` via bounded compare-and-swap.
+/// Remove the registry entry for `project` while holding the registry write
+/// lock.
 pub fn remove_entry(project: &Path) -> std::io::Result<()> {
     let canon = project
         .canonicalize()
         .unwrap_or_else(|_| project.to_path_buf());
-    let path = registry_file_path();
 
-    for _attempt in 0..CAS_RETRY_ATTEMPTS {
-        let pre_mtime = std::fs::metadata(&path)
-            .ok()
-            .and_then(|m| m.modified().ok());
+    with_registry_lock(|| {
         let mut registry = read_registry();
         let before = registry.daemons.len();
         registry.daemons.retain(|d| d.project != canon);
@@ -181,17 +221,8 @@ pub fn remove_entry(project: &Path) -> std::io::Result<()> {
             // Nothing to remove — caller's invariant satisfied.
             return Ok(());
         }
-        let post_mtime = std::fs::metadata(&path)
-            .ok()
-            .and_then(|m| m.modified().ok());
-        if pre_mtime == post_mtime {
-            return write_registry_atomic(&registry);
-        }
-    }
-    Err(std::io::Error::new(
-        std::io::ErrorKind::WouldBlock,
-        "daemon registry contended after 3 CAS attempts",
-    ))
+        write_registry_atomic(&registry)
+    })
 }
 
 /// One-shot migration from v0.2.x `daemon-active.json`.
@@ -278,9 +309,7 @@ mod tests {
     fn with_registry_dir<F: FnOnce(&Path)>(prefix: &str, f: F) {
         // Hold the lock for the entire body so set_var / f / remove_var
         // run atomically with respect to other tests in this module.
-        let _guard = REGISTRY_ENV_LOCK
-            .lock()
-            .unwrap_or_else(|e| e.into_inner());
+        let _guard = REGISTRY_ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
         let tmp = TempDir::new().expect("tempdir");
         std::env::set_var("TLDR_DAEMON_REGISTRY_DIR", tmp.path());
         let _prefix = prefix;

--- a/crates/tldr-cli/src/commands/daemon/start.rs
+++ b/crates/tldr-cli/src/commands/daemon/start.rs
@@ -141,6 +141,13 @@ impl DaemonStartArgs {
         let socket_path = compute_socket_path(project);
         let our_pid = std::process::id();
 
+        eprintln!(
+            "daemon_startup project={} pid={} socket={}",
+            project.display(),
+            our_pid,
+            socket_path.display()
+        );
+
         // VAL-003 (v0.3.0): register the daemon in the multi-daemon
         // registry. Replaces v0.2.x's single-slot daemon-active.json.
         // Failures are logged but non-fatal — the file is auxiliary

--- a/crates/tldr-cli/src/commands/daemon/start.rs
+++ b/crates/tldr-cli/src/commands/daemon/start.rs
@@ -27,6 +27,20 @@ use super::ipc::{check_socket_alive, cleanup_socket, compute_socket_path, IpcLis
 use super::pid::{compute_pid_path, try_acquire_lock};
 use super::types::DaemonConfig;
 
+fn append_daemon_log(project: &Path, line: &str) -> std::io::Result<()> {
+    use std::io::Write;
+
+    let log_path = project.join(".tldr").join("daemon.log");
+    if let Some(parent) = log_path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    let mut log = std::fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(log_path)?;
+    writeln!(log, "{}", line)
+}
+
 // =============================================================================
 // CLI Arguments
 // =============================================================================
@@ -96,7 +110,23 @@ impl DaemonStartArgs {
         let socket_path = compute_socket_path(&project);
         if socket_path.exists() && !check_socket_alive(&project).await {
             // Socket exists but daemon is not responding - stale
+            let _ = append_daemon_log(
+                &project,
+                &format!(
+                    "stale_socket_detected project={} socket={}",
+                    project.display(),
+                    socket_path.display()
+                ),
+            );
             cleanup_socket(&project)?;
+            let _ = append_daemon_log(
+                &project,
+                &format!(
+                    "stale_socket_removed project={} socket={}",
+                    project.display(),
+                    socket_path.display()
+                ),
+            );
         }
 
         if self.foreground {

--- a/crates/tldr-cli/tests/daemon_observability_test.rs
+++ b/crates/tldr-cli/tests/daemon_observability_test.rs
@@ -12,7 +12,7 @@
 
 use std::path::Path;
 use std::process::Command;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 use tempfile::TempDir;
 
 fn tldr_cmd() -> Command {
@@ -26,17 +26,7 @@ fn stop_daemon(project: &Path) {
         .output();
 }
 
-/// Contract: `daemon start` (background mode) must create
-/// `<project>/.tldr/daemon.log` and write at least one byte of daemon output
-/// to it. Prevents regression to the previous behavior where the spawned
-/// daemon's stdout and stderr were dropped to `/dev/null`, making any panic
-/// or tracing message invisible after the parent CLI exited.
-#[test]
-#[ignore = "spawns a real daemon and writes to ~/.tldr/registry.json — run manually with `cargo test -- --ignored`"]
-fn daemon_start_creates_nonempty_daemon_log() {
-    let temp = TempDir::new().expect("temp dir");
-    let project = temp.path();
-
+fn start_daemon(project: &Path) {
     let start = tldr_cmd()
         .args(["daemon", "start", "--project"])
         .arg(project)
@@ -48,11 +38,43 @@ fn daemon_start_creates_nonempty_daemon_log() {
         String::from_utf8_lossy(&start.stdout),
         String::from_utf8_lossy(&start.stderr),
     );
+}
+
+fn log_path(project: &Path) -> std::path::PathBuf {
+    project.join(".tldr").join("daemon.log")
+}
+
+fn read_log_until(project: &Path, needle: &str) -> String {
+    let path = log_path(project);
+    let start = Instant::now();
+    let mut content = String::new();
+    while start.elapsed() < Duration::from_secs(5) {
+        content = std::fs::read_to_string(&path).unwrap_or_default();
+        if content.contains(needle) {
+            return content;
+        }
+        std::thread::sleep(Duration::from_millis(100));
+    }
+    content
+}
+
+/// Contract: `daemon start` (background mode) must create
+/// `<project>/.tldr/daemon.log` and write at least one byte of daemon output
+/// to it. Prevents regression to the previous behavior where the spawned
+/// daemon's stdout and stderr were dropped to `/dev/null`, making any panic
+/// or tracing message invisible after the parent CLI exited.
+#[test]
+#[ignore = "spawns a real daemon and writes to ~/.tldr/registry.json — run manually with `cargo test -- --ignored`"]
+fn daemon_start_creates_nonempty_daemon_log() {
+    let temp = TempDir::new().expect("temp dir");
+    let project = temp.path();
+
+    start_daemon(project);
 
     // Give the detached child a brief moment to flush its first tracing line.
     std::thread::sleep(Duration::from_millis(500));
 
-    let log_path = project.join(".tldr").join("daemon.log");
+    let log_path = log_path(project);
     let metadata = std::fs::metadata(&log_path).unwrap_or_else(|e| {
         stop_daemon(project);
         panic!("expected {:?} to exist after `daemon start`, got: {}", log_path, e);
@@ -65,5 +87,36 @@ fn daemon_start_creates_nonempty_daemon_log() {
         len > 0,
         "expected {:?} to contain at least one byte of daemon output, was empty",
         log_path,
+    );
+}
+
+/// Contract: startup logs must identify the resolved project, daemon PID, and
+/// IPC socket path. These are the minimum stable fields needed to diagnose
+/// cross-cwd discovery and multi-daemon registry issues from daemon logs.
+#[test]
+#[ignore = "spawns a real daemon and writes to ~/.tldr/registry.json — run manually with `cargo test -- --ignored`"]
+fn daemon_start_logs_startup_metadata() {
+    let temp = TempDir::new().expect("temp dir");
+    let project = temp.path().canonicalize().expect("canonical project");
+
+    start_daemon(&project);
+    let log = read_log_until(&project, "daemon_startup");
+    stop_daemon(&project);
+
+    assert!(
+        log.contains("daemon_startup"),
+        "expected daemon_startup event in daemon.log, got: {}",
+        log
+    );
+    assert!(
+        log.contains(&format!("project={}", project.display())),
+        "expected startup log to include canonical project path {}; got: {}",
+        project.display(),
+        log
+    );
+    assert!(
+        log.contains(" pid=") && log.contains(" socket="),
+        "expected startup log to include pid and socket fields, got: {}",
+        log
     );
 }

--- a/crates/tldr-cli/tests/daemon_observability_test.rs
+++ b/crates/tldr-cli/tests/daemon_observability_test.rs
@@ -1,0 +1,69 @@
+//! Daemon observability contract tests (issue #67).
+//!
+//! Each test in this file locks down ONE externally-observable signal that the
+//! daemon must keep emitting so callers can answer "what just happened?" from
+//! logs alone. Tests are intentionally narrow — one signal per test — so a
+//! regression points at the exact contract that broke.
+//!
+//! All tests in this file spawn a real daemon process (which writes to
+//! `~/.tldr/registry.json`), so they are `#[ignore]` by default and run via
+//! `cargo test -p tldr-cli --test daemon_observability_test -- --ignored`.
+//! Same gating pattern as the daemon-spawn tests in `daemon_test.rs` (#68).
+
+use std::path::Path;
+use std::process::Command;
+use std::time::Duration;
+use tempfile::TempDir;
+
+fn tldr_cmd() -> Command {
+    Command::new(assert_cmd::cargo::cargo_bin!("tldr"))
+}
+
+fn stop_daemon(project: &Path) {
+    let _ = tldr_cmd()
+        .args(["daemon", "stop", "--project"])
+        .arg(project)
+        .output();
+}
+
+/// Contract: `daemon start` (background mode) must create
+/// `<project>/.tldr/daemon.log` and write at least one byte of daemon output
+/// to it. Prevents regression to the previous behavior where the spawned
+/// daemon's stdout and stderr were dropped to `/dev/null`, making any panic
+/// or tracing message invisible after the parent CLI exited.
+#[test]
+#[ignore = "spawns a real daemon and writes to ~/.tldr/registry.json — run manually with `cargo test -- --ignored`"]
+fn daemon_start_creates_nonempty_daemon_log() {
+    let temp = TempDir::new().expect("temp dir");
+    let project = temp.path();
+
+    let start = tldr_cmd()
+        .args(["daemon", "start", "--project"])
+        .arg(project)
+        .output()
+        .expect("spawn daemon start");
+    assert!(
+        start.status.success(),
+        "daemon start failed: stdout={:?} stderr={:?}",
+        String::from_utf8_lossy(&start.stdout),
+        String::from_utf8_lossy(&start.stderr),
+    );
+
+    // Give the detached child a brief moment to flush its first tracing line.
+    std::thread::sleep(Duration::from_millis(500));
+
+    let log_path = project.join(".tldr").join("daemon.log");
+    let metadata = std::fs::metadata(&log_path).unwrap_or_else(|e| {
+        stop_daemon(project);
+        panic!("expected {:?} to exist after `daemon start`, got: {}", log_path, e);
+    });
+    let len = metadata.len();
+
+    stop_daemon(project);
+
+    assert!(
+        len > 0,
+        "expected {:?} to contain at least one byte of daemon output, was empty",
+        log_path,
+    );
+}

--- a/crates/tldr-cli/tests/daemon_observability_test.rs
+++ b/crates/tldr-cli/tests/daemon_observability_test.rs
@@ -120,3 +120,29 @@ fn daemon_start_logs_startup_metadata() {
         log
     );
 }
+
+/// Contract: readiness must be visible as a stable log event after the daemon
+/// transitions to `Ready`. This gives tests and operators a non-timing-based
+/// signal that the daemon reached its IPC-serving state.
+#[test]
+#[ignore = "spawns a real daemon and writes to ~/.tldr/registry.json — run manually with `cargo test -- --ignored`"]
+fn daemon_start_logs_readiness_signal() {
+    let temp = TempDir::new().expect("temp dir");
+    let project = temp.path().canonicalize().expect("canonical project");
+
+    start_daemon(&project);
+    let log = read_log_until(&project, "daemon_ready");
+    stop_daemon(&project);
+
+    assert!(
+        log.contains("daemon_ready"),
+        "expected daemon_ready event in daemon.log, got: {}",
+        log
+    );
+    assert!(
+        log.contains(&format!("project={}", project.display())),
+        "expected readiness log to include canonical project path {}; got: {}",
+        project.display(),
+        log
+    );
+}

--- a/crates/tldr-cli/tests/daemon_observability_test.rs
+++ b/crates/tldr-cli/tests/daemon_observability_test.rs
@@ -58,6 +58,18 @@ fn read_log_until(project: &Path, needle: &str) -> String {
     content
 }
 
+#[cfg(unix)]
+fn socket_path_for_project(project: &Path) -> std::path::PathBuf {
+    let project_str = project
+        .canonicalize()
+        .unwrap_or_else(|_| project.to_path_buf())
+        .to_string_lossy()
+        .to_string();
+    let digest = md5::compute(project_str.as_bytes());
+    let hash = &format!("{:x}", digest)[..8];
+    std::env::temp_dir().join(format!("tldr-{}.sock", hash))
+}
+
 /// Contract: `daemon start` (background mode) must create
 /// `<project>/.tldr/daemon.log` and write at least one byte of daemon output
 /// to it. Prevents regression to the previous behavior where the spawned
@@ -143,6 +155,43 @@ fn daemon_start_logs_readiness_signal() {
         log.contains(&format!("project={}", project.display())),
         "expected readiness log to include canonical project path {}; got: {}",
         project.display(),
+        log
+    );
+}
+
+/// Contract: stale socket detection and recovery must be visible in the
+/// persistent daemon log. This distinguishes "daemon failed to start" from
+/// "startup recovered a dead socket left by an earlier daemon".
+#[cfg(unix)]
+#[test]
+#[ignore = "spawns a real daemon and writes to ~/.tldr/registry.json — run manually with `cargo test -- --ignored`"]
+fn daemon_start_logs_stale_socket_recovery() {
+    let temp = TempDir::new().expect("temp dir");
+    let project = temp.path().canonicalize().expect("canonical project");
+    let socket = socket_path_for_project(&project);
+
+    std::fs::write(&socket, b"stale socket placeholder").unwrap_or_else(|e| {
+        panic!("failed to create stale socket placeholder {:?}: {}", socket, e)
+    });
+
+    start_daemon(&project);
+    let log = read_log_until(&project, "stale_socket_removed");
+    stop_daemon(&project);
+
+    assert!(
+        log.contains("stale_socket_detected"),
+        "expected stale_socket_detected event in daemon.log, got: {}",
+        log
+    );
+    assert!(
+        log.contains("stale_socket_removed"),
+        "expected stale_socket_removed event in daemon.log, got: {}",
+        log
+    );
+    assert!(
+        log.contains(&format!("socket={}", socket.display())),
+        "expected stale-socket log to include socket path {}; got: {}",
+        socket.display(),
         log
     );
 }

--- a/crates/tldr-cli/tests/val013_daemon_status_cross_cwd_test.rs
+++ b/crates/tldr-cli/tests/val013_daemon_status_cross_cwd_test.rs
@@ -23,7 +23,10 @@
 
 use std::path::Path;
 use std::process::Command;
+use std::sync::Mutex;
 use std::time::{Duration, Instant};
+
+static DAEMON_TEST_LOCK: Mutex<()> = Mutex::new(());
 
 /// A scope guard that issues `daemon stop --project <fixture>` from the
 /// fixture cwd on drop, ensuring the daemon process is cleaned up even if
@@ -78,6 +81,8 @@ fn wait_for_daemon_running(project: &Path, timeout: Duration) -> bool {
 /// and reports `"running"` with the fixture project path.
 #[test]
 fn daemon_status_from_other_cwd_reports_running() {
+    let _guard = DAEMON_TEST_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+
     // Pre-test cleanup: stop any daemons left over from previous test runs
     // so the cross-cwd discovery has a single canonical active daemon to
     // resolve. Without this, leftover daemons yield "multiple daemons
@@ -180,6 +185,8 @@ fn daemon_status_from_other_cwd_reports_running() {
 /// the active-daemon fallback did not break the explicit-flag path.
 #[test]
 fn daemon_status_with_explicit_project_still_works_from_other_cwd() {
+    let _guard = DAEMON_TEST_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+
     let fixture = tempfile::Builder::new()
         .prefix("val013-workaround-")
         .tempdir()


### PR DESCRIPTION
Follow-up slice for #67 (daemon logging/observability contract). This PR is stacked after #70/#71/#72 until those land.

## What problem this PR solves

A stale IPC socket during startup is a recoverable condition, but without persistent observability it can look like an arbitrary slow or flaky daemon start.

The startup path already detects a dead socket and removes it before binding a fresh listener. The missing piece is an audit trail that distinguishes:

- daemon failed to start,
- daemon started normally,
- daemon started after recovering a stale socket left by an earlier process.

#67 explicitly calls out stale-socket detection/recovery as part of the logging contract. This PR makes that recovery visible.

## What this PR does

This PR persists two stable startup-recovery events to `<project>/.tldr/daemon.log`:

```text
stale_socket_detected project=<canonical-project> socket=<ipc-socket>
stale_socket_removed project=<canonical-project> socket=<ipc-socket>
```

And one ignored daemon-spawn test in `daemon_observability_test.rs` that locks down the contract:

- create a stale socket placeholder at the daemon's computed socket path,
- run `tldr daemon start --project <temp-project>`,
- assert the persistent daemon log contains both detection and removal events,
- assert the socket path is included for diagnosis.

## Why this slice is small

This PR is intentionally scoped to **stale-socket recovery observability**. It does not try to cover request-level traces, cache hit/miss visibility, local fallback visibility, or slow-request markers. Those are larger instrumentation surfaces and should remain separate follow-ups under #67.

## Stack / merge order

This PR is stacked after the earlier #67 slices because it extends the same observability test file and assumes persistent daemon logging exists.

Recommended order:

1. #70 — create/write `<project>/.tldr/daemon.log` and fix #64 registry race
2. #71 — startup metadata event
3. #72 — readiness signal event
4. **#73 — stale-socket recovery events**

## Verification

```bash
cargo test -p tldr-cli --test daemon_observability_test -- --ignored
# 4 passed
```

## Why the test is `#[ignore]`

The test spawns a real background daemon, binds a socket, touches the daemon's computed socket path, and writes to the daemon registry. It follows the same manual `--ignored` pattern used by #70 and documented in #68.

Refs #67. Does not close #67 by itself.
